### PR TITLE
refactor: 댓글 관련 코드 리팩토링

### DIFF
--- a/src/main/java/com/alom/reeltalkbe/domain/comment/service/CommentService.java
+++ b/src/main/java/com/alom/reeltalkbe/domain/comment/service/CommentService.java
@@ -44,17 +44,11 @@
 
         }
 
+        @Transactional
         public CommentResponseDTO add(CustomUserDetails userDetails, Long reviewId, CommentRequestDTO commentParamDTO){
-            if(userDetails == null){
-                throw new BaseException(BaseResponseStatus.FAIL_TOKEN_AUTHORIZATION);
-            }
+          User user = getUser(userDetails);
 
-            Long userId = userDetails.getUserId();
-
-            User user = userRepository.findById(userId)
-                    .orElseThrow(() -> new BaseException(BaseResponseStatus.NON_EXIST_USER));
-
-            Review review = reviewRepository.findById(reviewId)
+          Review review = reviewRepository.findById(reviewId)
                     .orElseThrow(() -> new  BaseException(BaseResponseStatus.INVALID_REVIEW));
 
 
@@ -68,17 +62,13 @@
             return new CommentResponseDTO(commentRepository.save(comment));
         }
 
+
+
+      @Transactional
         public CommentResponseDTO update(CustomUserDetails userDetails, Long commentId, Long reviewId, CommentRequestDTO commentRequestDTO) {
-            if(userDetails == null){
-                throw new BaseException(BaseResponseStatus.FAIL_TOKEN_AUTHORIZATION);
-            }
+        User user = getUser(userDetails);
 
-            Long userId = userDetails.getUserId();
-
-            User user = userRepository.findById(userId)
-                    .orElseThrow(() -> new  BaseException(BaseResponseStatus.NON_EXIST_USER));
-
-            Comment comment = commentRepository.findById(commentId)
+        Comment comment = commentRepository.findById(commentId)
                     .orElseThrow(() -> new BaseException(BaseResponseStatus.INVALID_COMMENT));
 
 
@@ -93,18 +83,12 @@
             return new CommentResponseDTO(commentRepository.save(comment));
 
         }
-
+        
+        @Transactional
         public void delete(CustomUserDetails userDetails, Long commentId, Long reviewId){
-            if(userDetails == null){
-                throw new BaseException(BaseResponseStatus.FAIL_TOKEN_AUTHORIZATION);
-            }
+          User user = getUser(userDetails);
 
-            Long userId = userDetails.getUserId();
-
-            User user = userRepository.findById(userId)
-                    .orElseThrow(() -> new BaseException(BaseResponseStatus.NON_EXIST_USER));
-
-            Comment comment = commentRepository.findById(commentId)
+          Comment comment = commentRepository.findById(commentId)
                     .orElseThrow(() -> new BaseException(BaseResponseStatus.INVALID_COMMENT));
 
             if (!comment.getUser().getId().equals(user.getId())) {
@@ -116,17 +100,12 @@
             commentRepository.deleteById(commentId);
         }
 
+        @Transactional
         public CommentResponseDTO updateLike(CustomUserDetails userDetails, Long commentId){
 
-            if(userDetails == null){
-                throw new BaseException(BaseResponseStatus.FAIL_TOKEN_AUTHORIZATION);
-            }
+          User user = getUser(userDetails);
 
-            Long userId = userDetails.getUserId();
-            User user = userRepository.findById(userId)
-                    .orElseThrow(() -> new BaseException(BaseResponseStatus.NON_EXIST_USER));
-
-            Comment comment = commentRepository.findById(commentId)
+          Comment comment = commentRepository.findById(commentId)
                     .orElseThrow(() -> new BaseException(BaseResponseStatus.INVALID_COMMENT));
 
             Optional<Like> existingLike = likeRepository.findByUserAndComment(user, comment);
@@ -156,4 +135,16 @@
             }
 
         }
+
+      private User getUser(CustomUserDetails userDetails) {
+        if(userDetails == null){
+          throw new BaseException(BaseResponseStatus.FAIL_TOKEN_AUTHORIZATION);
+        }
+
+        Long userId = userDetails.getUserId();
+
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new BaseException(BaseResponseStatus.NON_EXIST_USER));
+        return user;
+      }
     }


### PR DESCRIPTION
<h2>리팩토링 내용</h2>
<p>중복 코드 제거</p>
<p>transactional 어노테이션 추가</p><hr><p></p>
<h3>이슈 관련</h3><html>
<body>
<!--StartFragment--><p> 의견은 <b>일견 타당해 보이지만, 실무적으로는 몇 가지 중요한 위험과 단점</b>이 있어 일반적으로 권장되지 않는 방식입니다.</p><p>결론부터 말씀드리면, <b>서비스 계층에서 사용자 존재 여부를 다시 확인하는 현재 코드가 더 안전하고 견고한 설계</b>입니다. 코드를 그대로 두시는 것을 강력히 추천합니다.</p><p>그 이유는 다음과 같습니다.</p><hr><p></p><h3>## 1. 데이터 정합성 및 Race Condition 문제 (가장 중요)</h3><p></p><p>가장 큰 이유는 <b>요청 처리 시간차로 인한 데이터 불일치 가능성</b>입니다.</p><ul><li><p><b>요청 처리 흐름</b>: <code>Request</code> → <code>인증 필터</code> → <code>Controller</code> → <code>Service</code></p></li><li><p><b>문제 상황</b>:</p><ol start="1"><li><p>사용자의 토큰이 <code>인증 필터</code>를 정상적으로 통과했습니다. 이 시점에는 DB에 사용자가 분명히 존재합니다.</p></li><li><p>하지만 요청이 <code>Service</code>의 비즈니스 로직(예: 댓글 작성)에 도달하기까지의 그 짧은 시간 동안, <b>관리자가 해당 사용자를 탈퇴시키거나 계정을 비활성화</b>할 수 있습니다.</p></li><li><p>만약 서비스 계층에서 사용자 존재 여부를 재확인하지 않는다면, 이미 DB에서 사라진 사용자의 ID로 댓글을 생성하려는 시도를 하게 됩니다.</p></li><li><p><b>결과</b>: DB의 외래 키(Foreign Key) 제약 조건 때문에 <code>DataIntegrityViolationException</code> 같은 심각한 DB 에러가 발생하며 서버가 비정상 종료될 수 있습니다.</p></li></ol></li></ul><p>현재 코드처럼 서비스 로직 시작점에서 <code>userRepository.findById()</code>를 호출하면, 이러한 <code>Race Condition</code>을 방지하고 "존재하지 않는 사용자입니다"와 같이 <b>의도된 예외를 안전하게 발생</b>시킬 수 있습니다.</p><p></p><h3>## 2. 영속성 컨텍스트(Persistence Context)와 분리된 객체(Detached Entity)</h3><p></p><p><code>인증 필터</code>에서 조회한 <code>User</code> 객체와 <code>Service</code>의 <code>@Transactional</code> 내에서 다루는 <code>User</code> 객체는 다릅니다.</p><ul><li><p><b>필터의 User 객체</b>: 필터의 트랜잭션 범위 내에서 조회된 후, 해당 트랜잭션이 끝나면 <b>영속성 컨텍스트에서 분리된(Detached)</b> 상태가 됩니다.</p></li><li><p><b>서비스의 User 객체</b>: 서비스의 <code>@Transactional</code>이 시작되면서 <b>새로운 영속성 컨텍스트</b>가 열립니다. 여기서 안정적으로 데이터를 다루려면 이 컨텍스트 내에서 관리되는 **관리 상태(Managed)**의 객체를 사용해야 합니다.</p></li></ul><p><code>userRepository.findById()</code>를 다시 호출하는 것은 현재 트랜잭션의 영속성 컨텍스트 안으로 <code>User</code> 엔티티를 가져와 관리 상태로 만드는, 매우 중요하고 올바른 과정입니다. 분리된 객체를 그대로 사용하려 하면 예기치 않은 JPA 관련 오류를 만날 수 있습니다.</p><p></p><h3>## 3. 계층 간 책임 분리 (Separation of Concerns)</h3><p></p><p>소프트웨어 설계에서 각 계층은 자신만의 명확한 책임이 있습니다.</p><ul><li><p><b>인증 필터의 책임</b>: "이 요청이 유효한 사용자의 것인가?"를 판단하여 <b>인증(Authentication)</b> 정보를 <code>SecurityContext</code>에 설정하는 것입니다.</p></li><li><p><b>서비스 계층의 책임</b>: 전달받은 데이터를 기반으로 <b>비즈니스 로직을 수행</b>하고, 그 과정에서 <b>데이터의 무결성과 일관성을 보장</b>하는 것입니다.</p></li></ul><p>서비스 계층이 "필터가 이미 검증했겠지"라고 가정하는 순간, 필터의 구현 방식에 강하게 의존하게 됩니다(강한 결합). 만약 나중에 성능상의 이유로 필터에서 DB 조회를 제거하고 토큰의 유효성만 검사하도록 변경한다면, 서비스 계층의 모든 로직이 깨지게 됩니다.</p><p>서비스 계층은 독립적으로 자신의 로직에 필요한 모든 데이터의 유효성을 검증해야 합니다.</p><hr><p></p><h3>## 결론: 성능 vs 안정성</h3><p></p><p>물론 DB 조회가 한 번 더 일어나는 것은 맞습니다. 하지만 <code>findById</code>는 테이블의 Primary Key(PK)를 이용한 조회이므로 <b>인덱스를 통해 매우 빠르게 동작</b>합니다.</p><p>이 <b>미미한 성능 이득을 위해 시스템 전체의 안정성과 데이터 정합성을 포기하는 것은 매우 위험한 선택</b>입니다.</p><p>따라서, "토큰 필터에서 검증했으니 서비스에서는 생략해도 된다"는 의견은 이론적으로는 가능해 보일 수 있으나, <b>안정적인 백엔드 시스템을 구축하는 관점에서는 서비스 계층에서 다시 한번 검증하는 현재의 코드가 올바른 방향</b>입니다.</p><!--EndFragment-->
</body>
</html>
